### PR TITLE
Reorder Vector Institute talk and style fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -724,12 +724,12 @@ journal = {The Astrophysical Journal Letters}
     <heading>Talks</heading>
     <div class="talks-list">
       <p class="talk-item"><a href="https://youtu.be/LF22szp7ouo" target="_blank">Teaching ChatGPT to Do Real Science</a><br><span class="talk-venue">Fraser Cain / Universe Today Podcast</span></p>
+      <p class="talk-item"><a href="https://vectorinstitute.ai/foundation-models-science-workshop-recap/" target="_blank">Panelist, "AI & Physics: Learning from Each Other" (Not recorded)</a><br><span class="talk-venue">Vector Institute Foundation Models for Science, Toronto, 2025</span></p>
       <p class="talk-item"><a href="https://pirsa.org/25040062" target="_blank">UniverseTBD & AstroCoder (10:00-)</a><br><span class="talk-venue">Theory + AI Symposium, Perimeter Institute</span></p>
       <p class="talk-item"><a href="https://www.youtube.com/live/r-Or1kEM1wo" target="_blank">Gravity Bench: A Benchmark on Gravitational Physics Discovery for Agents</a><br><span class="talk-venue">ESO Natural Language Processing in Astronomy</span></p>
       <p class="talk-item"><a href="https://www.cosmos.esa.int/web/natural-language-processing-for-space-science/videos-recordings" target="_blank">Gravity Bench: A Benchmark on Gravitational Physics Discovery for Agents</a><br><span class="talk-venue">NLP for Space Science Workshop, ESA/ESAC, Madrid</span></p>
       <p class="talk-item"><a href="https://youtu.be/2BXLR-UYUns" target="_blank">SpectraFM: Tuning into Stellar Foundation Models</a><br><span class="talk-venue">AstroAI Workshop, Harvard-Smithsonian CfA</span></p>
       <p class="talk-item"><a href="https://youtu.be/KG75DUmQ3pQ" target="_blank">ChatGaia: Talk to the Gaia Archive in Natural Language</a><br><span class="talk-venue">Debating the Potential of Machine Learning in Astronomical Surveys, Flatiron</span></p>
-      <p class="talk-item"><a href="https://vectorinstitute.ai/foundation-models-science-workshop-recap/" target="_blank">Panelist, "AI & Physics: Learning from Each Other"</a> (Not recorded)<br><span class="talk-venue">Vector Institute Foundation Models for Science, Toronto, 2025</span></p>
     </div>
 
     <!-- Footer -->


### PR DESCRIPTION
Moved to second position and included "(Not recorded)" inside the link.

https://claude.ai/code/session_01UzEkBcbcSHU8EgrAJi8MM1