### PR TITLE
Make the galaxy wiki usable on mobile

### DIFF
--- a/galaxywiki/assets/app.js
+++ b/galaxywiki/assets/app.js
@@ -5,6 +5,7 @@ const state = {
   slug: null,
   query: "",
   filter: "all",
+  filtersOpen: false,
   searchMode: "name",
   coordRA: "",
   coordDec: "",
@@ -683,9 +684,21 @@ function filterbarHTML() {
       return `<button class="${active ? `on ${state.sortDir}` : ""}" data-sort="${key}" title="Sort ${next}">${label}${dir}</button>`;
     })
     .join("");
-  const filterCount = getFilters().length - 1;
+  const allFilters = getFilters();
+  const filterCount = allFilters.length - 1;
+  const active = allFilters.find((f) => f.id === state.filter) || allFilters[0];
+  const activeLabel = active.id === "all" ? "All galaxies" : active.label;
+  const activeCount = active.count ?? state.entities.filter(active.test).length;
   return `
-    <aside class="filter-rail">
+    <aside class="filter-rail ${state.filtersOpen ? "open" : ""}">
+      <button class="filter-toggle ${state.filter !== "all" ? "is-filtered" : ""}" data-action="toggle-filters" aria-expanded="${state.filtersOpen ? "true" : "false"}">
+        <span class="ft-lead">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><line x1="4" y1="6" x2="20" y2="6"></line><line x1="7" y1="12" x2="17" y2="12"></line><line x1="10" y1="18" x2="14" y2="18"></line></svg>
+          <span>Filter &amp; sort</span>
+        </span>
+        <span class="ft-current">${escapeHTML(activeLabel)} <span class="ft-ct">${fmtCount(activeCount)}</span></span>
+        <svg class="ft-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="m6 9 6 6 6-6"></path></svg>
+      </button>
       <div class="rail-block">
         <div class="rail-head">Sort</div>
         <div class="rail-sort">${sorts}</div>
@@ -1304,6 +1317,7 @@ function handleClick(event) {
   const filterButton = event.target.closest("[data-filter]");
   if (filterButton) {
     state.filter = filterButton.dataset.filter;
+    state.filtersOpen = false;
     state.coordResults = null;
     resetVisibleLimit();
     if (!state.fullIndexLoaded) loadFullIndex({ renderAfter: true });
@@ -1337,7 +1351,10 @@ function handleClick(event) {
   const actionButton = event.target.closest("[data-action]");
   if (actionButton) {
     const action = actionButton.dataset.action;
-    if (action === "home") {
+    if (action === "toggle-filters") {
+      state.filtersOpen = !state.filtersOpen;
+      refreshGalleryResults();
+    } else if (action === "home") {
       event.preventDefault();
       goHome();
     } else if (action === "home-reset") {

--- a/galaxywiki/assets/styles.css
+++ b/galaxywiki/assets/styles.css
@@ -1103,12 +1103,6 @@ code {
 }
 
 @media (max-width: 720px) {
-  .coord-field {
-    grid-template-columns: 1fr;
-  }
-  .find-btn {
-    padding: 14px;
-  }
   .coord-hit {
     grid-template-columns: 72px 1fr auto;
     gap: 14px;
@@ -1406,6 +1400,77 @@ code {
   gap: 6px;
 }
 
+/* Collapsible filter trigger — only shown below the desktop breakpoint */
+.filter-toggle {
+  display: none;
+  width: 100%;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border: 1px solid var(--line-strong);
+  border-radius: 11px;
+  background: var(--bg-2);
+  color: var(--ink-dim);
+  text-align: left;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.filter-toggle:hover {
+  border-color: var(--accent-dim);
+}
+
+.filter-toggle.is-filtered {
+  border-color: var(--accent-dim);
+  color: var(--ink);
+}
+
+.filter-toggle .ft-lead {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  flex-shrink: 0;
+}
+
+.filter-toggle .ft-lead svg {
+  width: 15px;
+  height: 15px;
+  color: var(--accent);
+}
+
+.filter-toggle .ft-current {
+  margin-left: auto;
+  font-size: 13px;
+  color: var(--ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.filter-toggle .ft-ct {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-faint);
+  margin-left: 3px;
+}
+
+.filter-toggle .ft-chev {
+  width: 16px;
+  height: 16px;
+  color: var(--ink-faint);
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+}
+
+.filter-rail.open .filter-toggle .ft-chev {
+  transform: rotate(180deg);
+}
+
 @media (max-width: 1040px) {
   .console {
     grid-template-columns: 1fr;
@@ -1421,12 +1486,30 @@ code {
     max-height: none;
     overflow: visible;
     order: -1;
+    flex-direction: column;
+    gap: 16px;
+  }
+  .filter-toggle {
+    display: flex;
+  }
+  /* Concept list is hidden behind the toggle so the grid sits right below it */
+  .filter-rail:not(.open) .rail-block {
+    display: none;
+  }
+  .filter-rail.open .rail-block {
+    padding-top: 4px;
+  }
+  .filter-rail.open .rail-chips {
+    max-height: 46vh;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 2px 2px 4px;
+    margin: -2px;
+  }
+  .filter-rail.open .rail-sort {
     flex-direction: row;
     flex-wrap: wrap;
-    gap: 16px 32px;
-  }
-  .rail-block {
-    flex: 1 1 auto;
+    gap: 10px 20px;
   }
 }
 
@@ -1694,5 +1777,118 @@ code {
     grid-column: 2;
     grid-row: 1;
     justify-self: end;
+  }
+}
+
+/* ============================================================
+   Phone layout. Comes after every base rule so these win
+   regardless of earlier source order.
+   ============================================================ */
+@media (max-width: 600px) {
+  .gallery-page {
+    padding: 0 16px 56px;
+  }
+
+  .console {
+    padding: 24px 0 22px;
+    gap: 20px;
+  }
+
+  /* Stack RA / Dec / button so nothing overflows the viewport.
+     minmax(0, …) lets the tracks shrink past the inputs' intrinsic size. */
+  .coord-field {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 8px;
+  }
+
+  .coord-cell {
+    min-width: 0;
+  }
+
+  .find-btn {
+    grid-column: 1 / -1;
+    padding: 13px;
+    width: 100%;
+  }
+
+  .sb-field {
+    padding: 12px 14px;
+    border-radius: 10px;
+  }
+
+  .coord-cell {
+    padding: 11px 12px;
+    border-radius: 10px;
+  }
+
+  .sb-hint {
+    line-height: 1.45;
+  }
+
+  /* Two-up tiles read better than tiny three-up ones on a phone */
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .tile .name {
+    font-size: 16px;
+  }
+
+  /* Dossier sources: stack the citation meta above its passage */
+  .source {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+
+  .source-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 4px 10px;
+  }
+
+  .source-meta .as {
+    margin-top: 0;
+  }
+
+  .source-body .summary {
+    font-size: 16.5px;
+  }
+
+  .entry-head {
+    gap: 24px;
+  }
+
+  .title-block h1 {
+    margin-bottom: 16px;
+  }
+
+  .infobox {
+    grid-template-columns: 1fr;
+    gap: 2px 0;
+  }
+
+  .infobox dt {
+    margin-top: 12px;
+  }
+
+  .infobox dd {
+    margin-bottom: 2px;
+  }
+
+  .section-head h2 {
+    font-size: 19px;
+  }
+
+  .coord-results-head {
+    flex-wrap: wrap;
+    gap: 8px 16px;
+  }
+}
+
+/* Very narrow phones: a single column of coordinate inputs */
+@media (max-width: 380px) {
+  .coord-field {
+    grid-template-columns: minmax(0, 1fr);
   }
 }


### PR DESCRIPTION
Three problems on phones, all fixed:

- Search console overflowed horizontally. The RA/Dec coordinate
  inputs never collapsed because the base `.coord-field` rule sat
  after the mobile override in source order, and the `1fr` tracks were
  floored by each input's ~20-char intrinsic width. The whole page was
  ~700px wide on a 390px screen, cutting off the headline, search box,
  and hints. Now the coordinate field stacks (2-up, then 1-up under
  380px) with `minmax(0, 1fr)` tracks and a full-width "Find nearest"
  button. No horizontal overflow from 320px up.

- The UAT concept filters (145 chips) rendered as a wall above the
  grid, so you scrolled past all of them to reach a single galaxy.
  Below the desktop breakpoint they now collapse behind a compact
  "Filter & sort" disclosure that shows the active filter; the grid
  sits right beneath it. Picking a concept closes the panel and jumps
  straight to results. Desktop keeps its sidebar rail unchanged.

- Dossier source entries used a fixed 130px meta column, squeezing
  each passage into a narrow strip. On phones the citation meta now
  wraps above its passage and the summary gets full width. Plus
  smaller polish: 2-up gallery tiles, single-column infobox, tighter
  spacing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M6BnBF6Wxiy3ec7FGvz4fy